### PR TITLE
bug: considering empty version as not selected add-on

### DIFF
--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -52,8 +52,7 @@ type AddOn struct {
 }
 
 type Linter struct {
-	staticVersions map[string]AddOn
-	apiBaseURL     *url.URL
+	apiBaseURL *url.URL
 }
 
 // New returns a new v1beta1.Installer linter. this linter is capable of evaluating if a
@@ -69,10 +68,6 @@ func New(opts ...Option) *Linter {
 // Versions return a map containing all supported versions indexed by add-on name. it
 // goes and fetch the versions from a remote endpoint.
 func (l *Linter) Versions(ctx context.Context, inst v1beta1.Installer) (map[string]AddOn, error) {
-	if l.staticVersions != nil {
-		return l.staticVersions, nil
-	}
-
 	content, err := l.replaceAPIBaseURL(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error preparing for api requests: %w", err)

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -37,30 +37,6 @@ import (
 //go:embed tests
 var staticTests embed.FS
 
-func TestStaticVersions(t *testing.T) {
-	static := map[string]AddOn{
-		"addon0": {
-			Latest: "1.0.0",
-			Versions: []string{
-				"1.0.0",
-				"2.0.0",
-				"3.0.0",
-			},
-		},
-	}
-
-	var empty v1beta1.Installer
-	linter := New(WithStaticVersions(static))
-	res, err := linter.Versions(context.Background(), empty)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	if !reflect.DeepEqual(res, static) {
-		t.Errorf("expecting %+v, received %+v", static, res)
-	}
-}
-
 func TestValidateWithWrongAPIEndpointReturn(t *testing.T) {
 	mocksrv := httptest.NewServer(
 		http.HandlerFunc(

--- a/pkg/lint/options.go
+++ b/pkg/lint/options.go
@@ -29,11 +29,3 @@ func WithAPIBaseURL(u *url.URL) Option {
 		l.apiBaseURL = u
 	}
 }
-
-// WithStaticVersions set an static version of addon versions, avoids going to the the remote
-// api to fetch a new list from time to time.
-func WithStaticVersions(versions map[string]AddOn) Option {
-	return func(l *Linter) {
-		l.staticVersions = versions
-	}
-}

--- a/pkg/lint/rego/functions.rego
+++ b/pkg/lint/rego/functions.rego
@@ -17,41 +17,41 @@ package kurl.installer
 # or rke2). this is useful if we want to check how many got selected and return an error if more
 # than one has been selected.
 kube_distributions[distro] {
-	installer.spec.kubernetes.version
+	installer.spec.kubernetes.version != ""
 	distro := "kubernetes"
 }
 kube_distributions[distro] {
-	installer.spec.k3s.version
+	installer.spec.k3s.version != ""
 	distro := "k3s"
 }
 kube_distributions[distro] {
-	installer.spec.rke2.version
+	installer.spec.rke2.version != ""
 	distro := "rke2"
 }
 
 # container_runtime gather the selected container runtimes in an array. we use this to evaluate
 # how many of them got selected.
 container_runtimes[runtime] {
-	installer.spec.docker.version
+	installer.spec.docker.version != ""
 	runtime := "docker"
 }
 container_runtimes[runtime] {
-	installer.spec.containerd.version
+	installer.spec.containerd.version != ""
 	runtime := "containerd"
 }
 
 # cni_providers gather the selected cni providers in an array. we use this to evaluate
 # how many of them got selected.
 cni_providers[runtime] {
-	installer.spec.flannel.version
+	installer.spec.flannel.version != ""
 	runtime := "flannel"
 }
 cni_providers[runtime] {
-	installer.spec.weave.version
+	installer.spec.weave.version != ""
 	runtime := "weave"
 }
 cni_providers[runtime] {
-	installer.spec.antrea.version
+	installer.spec.antrea.version != ""
 	runtime := "antrea"
 }
 
@@ -170,10 +170,10 @@ valid_antrea_pod_cidr_override() {
 	valid_ipv6_cidr(installer.spec.antrea.podCIDR)
 }
 
-# valid_addon_version checks if the version for the addon exists (is valid). if the addon
+# valid_add_on_version checks if the version for the addon exists (is valid). if the addon
 # has not been selected (there is no version specified for it) then this evaluates to true.
 valid_add_on_version(addon) {
-	not installer.spec[addon].version
+	installer.spec[addon].version == ""
 }
 valid_add_on_version(addon) {
 	addon_version_exists(addon, installer.spec[addon].version)

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -17,7 +17,7 @@ package kurl.installer
 # selected a container runtime. a container runtime is necessary to run the kube
 # distribution.
 lint[output] {
-	installer.spec.kubernetes.version
+	installer.spec.kubernetes.version != ""
 	count(container_runtimes) == 0
 	output :=  {
 		"type": "misconfiguration",
@@ -40,7 +40,7 @@ lint[output] {
 # generates an error if kubernetes is the selected distribution but no cni plugin has
 # been selected by the user.
 lint[output] {
-	installer.spec.kubernetes.version
+	installer.spec.kubernetes.version != ""
 	count(cni_providers) == 0
 	output :=  {
 		"type": "misconfiguration",
@@ -328,7 +328,7 @@ lint[output] {
 
 # this next rule evaluates if all selected add-ons are supported by k3s.
 lint[output] {
-	installer.spec.k3s
+	installer.spec.k3s.version != ""
 	installer.spec[addon]
 	not add_on_compatible_with_k3s(addon)
 	output := {
@@ -340,7 +340,7 @@ lint[output] {
 
 # this next rule evaluates if all selected add-ons are supported by rke2.
 lint[output] {
-	installer.spec.rke2
+	installer.spec.rke2.version != ""
 	installer.spec[addon]
 	not add_on_compatible_with_rke2(addon)
 	output := {
@@ -351,8 +351,8 @@ lint[output] {
 }
 
 lint[output] {
-	installer.spec.k3s.version
-	installer.spec.kotsadm.uiBindPort
+	installer.spec.k3s.version != ""
+	installer.spec.kotsadm.uiBindPort != ""
 	port_out_of_range(installer.spec.kotsadm.uiBindPort, 30000, 32767)
 	output := {
 		"type": "misconfiguration",
@@ -362,8 +362,8 @@ lint[output] {
 }
 
 lint[output] {
-	installer.spec.rke2.version
-	installer.spec.kotsadm.uiBindPort
+	installer.spec.rke2.version != ""
+	installer.spec.kotsadm.uiBindPort != ""
 	port_out_of_range(installer.spec.kotsadm.uiBindPort, 30000, 32767)
 	output := {
 		"type": "misconfiguration",
@@ -376,7 +376,7 @@ lint[output] {
 lint[output] {
 	is_addon_version_greater_than_or_equal("rook", "1.8.0")
 	is_addon_version_lower_than("rook", "1.9.0")
-	installer.spec.ekco.version
+	installer.spec.ekco.version != ""
 	is_addon_version_lower_than("ekco", "0.22.0")
 	output := {
 		"type": "incompatibility",
@@ -388,7 +388,7 @@ lint[output] {
 # verifies rook 1.9.x is not compatible with EKCO versions < 0.23.0
 lint[output] {
 	is_addon_version_greater_than_or_equal("rook", "1.9.0")
-	installer.spec.ekco.version
+	installer.spec.ekco.version != ""
 	is_addon_version_lower_than("ekco", "0.23.0")
 	output := {
 		"type": "incompatibility",

--- a/pkg/lint/tests/rego/empty_versions.yaml
+++ b/pkg/lint/tests/rego/empty_versions.yaml
@@ -1,0 +1,53 @@
+installer:
+  spec:
+    antrea:
+      version: ""
+    calico:
+      version: ""
+    certManager:
+      version: ""
+    collectd:
+      version: ""
+    containerd:
+      version: 1.5.11
+    contour:
+      version: ""
+    docker:
+      version: ""
+    ekco:
+      version: 0.19.9
+    fluentd:
+      version: ""
+    helm:
+      helmfileSpec: ""
+    k3s:
+      version: ""
+    kotsadm:
+      version: 1.87.0
+    kubernetes:
+      version: 1.21.14
+    longhorn:
+      uiReplicaCount: 1
+      version: 1.2.4
+    metricsServer:
+      version: ""
+    minio:
+      version: 2022-08-02T23-59-16Z
+    openebs:
+      version: ""
+    prometheus:
+      version: 0.58.0-39.4.0
+    registry:
+      publishPort: 5000
+      version: 2.8.1
+    rke2:
+      version: ""
+    rook:
+      version: ""
+    sonobuoy:
+      version: ""
+    velero:
+      version: 1.9.0
+    weave:
+      version: 2.6.5-20220720
+output: []

--- a/pkg/lint/tests/unmarshal/empty_versions.yaml
+++ b/pkg/lint/tests/unmarshal/empty_versions.yaml
@@ -1,0 +1,61 @@
+err: ""
+data: |
+  apiVersion: "cluster.kurl.sh/v1beta1"
+  kind: "Installer"
+  metadata:
+    name: "latest"
+  spec:
+    antrea:
+      version: ""
+    calico:
+      version: ""
+    certManager:
+      version: ""
+    collectd:
+      version: ""
+    containerd:
+      version: 1.5.11
+    contour:
+      version: 1.21.1
+    docker:
+      version: ""
+    ekco:
+      version: 0.19.3
+    firewalldConfig: {}
+    fluentd:
+      version: ""
+    helm:
+      helmfileSpec: ""
+    iptablesConfig: {}
+    k3s:
+      version: ""
+    kotsadm:
+      version: 1.78.0
+    kubernetes:
+      version: 1.23.9
+    kurl: {}
+    longhorn:
+      version: 1.3.1
+    metricsServer:
+      version: ""
+    minio:
+      version: ""
+    openebs:
+      version: ""
+    prometheus:
+      version: 0.58.0-39.4.0
+    registry:
+      version: 2.8.1
+    rke2:
+      version: ""
+    rook:
+      version: ""
+    selinuxConfig: {}
+    sonobuoy:
+      version: ""
+    ufwConfig: {}
+    velero:
+      version: ""
+    weave:
+      version: 2.6.5-20220720
+output: []


### PR DESCRIPTION
if a given add-on has an empty string on its version property we now consider the add-on as not being selected.

this pr also removes some dead code that was useful in a prior implementation but is not needed in the current one.