### PR TITLE
bug: fix multi-x in add-on version

### DIFF
--- a/pkg/lint/rego/functions.rego
+++ b/pkg/lint/rego/functions.rego
@@ -103,6 +103,7 @@ addon_version_exists(addon, version) {
 addon_version_exists(addon, version) {
 	endswith(version, "x")
 	x_version_removed := replace(version, "x", "")
+	x_version_removed != ""
 	startswith(known_versions[addon].versions[_], x_version_removed)
 }
 

--- a/pkg/lint/tests/rego/invalid_addon_xxx_version.yaml
+++ b/pkg/lint/tests/rego/invalid_addon_xxx_version.yaml
@@ -1,0 +1,12 @@
+installer:
+  spec:
+    kubernetes:
+      version: latest
+    containerd:
+      version: latest
+    weave:
+      version: xxx
+output:
+  - message: Unknown weave add-on version xxx
+    field: spec.weave.version
+    type: unknown-addon


### PR DESCRIPTION
if a given version was set to a string of x's it was being evaluatee as a valid version as we were trimming all x's and not only the last one.

something like the following would be considered a valid version:

```
spec:
  containerd:
     version: xxx
```