### PR TITLE
feat: flannel is incompatible with docker runtime

### DIFF
--- a/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: installers.cluster.kurl.sh
 spec:

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -353,3 +353,15 @@ lint[output] {
 		"field": "spec.containerd"
 	}
 }
+
+# verifies if flannel is compatible with the selected container runtime. flannel and docker are
+# incompatible. containerd is required.
+lint[output] {
+	installer.spec.docker.version != ""
+	installer.spec.flannel.version != ""
+	output := {
+		"type": "incompatibility",
+		"message": "Flannel is not compatible with the Docker runtime, Containerd is required",
+		"field": "spec.docker"
+	}
+}

--- a/pkg/lint/tests/rego/invalid_flannel_docker.yaml
+++ b/pkg/lint/tests/rego/invalid_flannel_docker.yaml
@@ -1,0 +1,12 @@
+installer:
+  spec:
+    kubernetes:
+      version: latest
+    docker:
+      version: latest
+    flannel:
+      version: latest
+output:
+  - message: Flannel is not compatible with the Docker runtime, Containerd is required
+    field: spec.docker
+    type: incompatibility

--- a/pkg/lint/tests/rego/valid_flannel_containerd.yaml
+++ b/pkg/lint/tests/rego/valid_flannel_containerd.yaml
@@ -1,0 +1,9 @@
+installer:
+  spec:
+    kubernetes:
+      version: latest
+    containerd:
+      version: latest
+    flannel:
+      version: latest
+output: []


### PR DESCRIPTION
Flannel and docker appear to be incompatible in some configurations.

https://github.com/replicatedhq/kURL/pull/4014

Rather than try to support these configurations, add an incompatibility since docker is deprecated and will no longer be supported in the near future.