### PR TITLE
chore: add error if selected kubernetes is >= 1.22 and rook is less than 1.4.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ bin/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE
+.idea/

--- a/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: installers.cluster.kurl.sh
 spec:

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -164,7 +164,7 @@ lint[output] {
 	}
 }
 
-# returns an error if selected kubernetes is >= 1.22 and rook is less than 1.1.0.
+# returns an error if selected kubernetes is >= 1.20 and rook is less than 1.1.0.
 lint[output] {
 	is_addon_version_greater_than_or_equal("kubernetes", "1.20.0")
 	is_addon_version_lower_than("rook", "1.1.0")
@@ -178,7 +178,8 @@ lint[output] {
 # returns an error if selected kubernetes is >= 1.22 and rook is less than 1.4.9.
 lint[output] {
 	is_addon_version_greater_than_or_equal("kubernetes", "1.22.0")
-	is_addon_version_lower_than("rook", "1.4.9")
+	is_addon_version_greater_than_or_equal("rook", "1.1.1")
+	is_addon_version_lower_than("rook", "1.5.0")
 	output := {
 		"type": "incompatibility",
 		"message": "Rook versions <= 1.4.9 are not compatible with Kubernetes versions 1.22+",

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -178,7 +178,6 @@ lint[output] {
 # returns an error if selected kubernetes is >= 1.22 and rook is less than 1.4.9.
 lint[output] {
 	is_addon_version_greater_than_or_equal("kubernetes", "1.22.0")
-	is_addon_version_greater_than_or_equal("rook", "1.1.1")
 	is_addon_version_lower_than("rook", "1.5.0")
 	output := {
 		"type": "incompatibility",

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -164,13 +164,24 @@ lint[output] {
 	}
 }
 
-# returns an error if selected kubernetes is >= 1.20 and rook is less than 1.1.0.
+# returns an error if selected kubernetes is >= 1.22 and rook is less than 1.1.0.
 lint[output] {
 	is_addon_version_greater_than_or_equal("kubernetes", "1.20.0")
 	is_addon_version_lower_than("rook", "1.1.0")
 	output := {
 		"type": "incompatibility",
 		"message": "Rook versions <= 1.1.0 are not compatible with Kubernetes versions 1.20+",
+		"field": "spec.rook.version"
+	}
+}
+
+# returns an error if selected kubernetes is >= 1.22 and rook is less than 1.4.9.
+lint[output] {
+	is_addon_version_greater_than_or_equal("kubernetes", "1.22.0")
+	is_addon_version_lower_than("rook", "1.4.9")
+	output := {
+		"type": "incompatibility",
+		"message": "Rook versions <= 1.4.9 are not compatible with Kubernetes versions 1.22+",
 		"field": "spec.rook.version"
 	}
 }

--- a/pkg/lint/tests/rego/rook_1.0.4_kube_gt_1.20.yaml
+++ b/pkg/lint/tests/rego/rook_1.0.4_kube_gt_1.20.yaml
@@ -12,3 +12,6 @@ output:
   - message: Rook versions <= 1.1.0 are not compatible with Kubernetes versions 1.20+
     field: spec.rook.version
     type: incompatibility
+  - message: Rook versions <= 1.4.9 are not compatible with Kubernetes versions 1.22+
+    field: spec.rook.version
+    type: incompatibility

--- a/pkg/lint/tests/rego/rook_1.4.9_kube_gt_1.22.yaml
+++ b/pkg/lint/tests/rego/rook_1.4.9_kube_gt_1.22.yaml
@@ -7,7 +7,7 @@ installer:
     weave:
       version: latest
     rook: 
-      version: 1.4.9
+      version: 1.4.3
 output:
   - message: Rook versions <= 1.4.9 are not compatible with Kubernetes versions 1.22+
     field: spec.rook.version

--- a/pkg/lint/tests/rego/rook_1.4.9_kube_gt_1.22.yaml
+++ b/pkg/lint/tests/rego/rook_1.4.9_kube_gt_1.22.yaml
@@ -1,0 +1,14 @@
+installer:
+  spec: 
+    kubernetes: 
+      version: 1.22.x
+    containerd: 
+      version: latest
+    weave:
+      version: latest
+    rook: 
+      version: 1.4.9
+output:
+  - message: Rook versions <= 1.4.9 are not compatible with Kubernetes versions 1.22+
+    field: spec.rook.version
+    type: incompatibility


### PR DESCRIPTION
## Description

Rook 1.4.9 and lower does not work with k8s >=1.22
Therefore, this PR adds a lint for we are able to let the users be aware of.

Closes: [sc-68952]
See: https://github.com/replicatedhq/kURL-api/pull/153