### PR TITLE
feat: valero <= 1.6.2 incompatible with k8s 1.22+

### DIFF
--- a/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.2
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: installers.cluster.kurl.sh
 spec:

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -329,6 +329,16 @@ lint[output] {
 	}
 }
 
+# verifies velero 1.7.0 is not compatible with kubernetes versions >= 1.22+
+lint[output] {
+	is_addon_version_greater_than_or_equal("kubernetes", "1.22.0")
+	is_addon_version_lower_than("velero", "1.6.3")
+	output := {
+		"type": "incompatibility",
+		"message": "Velero versions <= 1.6.2 are not compatible with Kubernetes versions 1.22+",
+		"field": "spec.velero.version"
+	}
+}
 # verifies rook 1.9.x is not compatible with EKCO versions < 0.23.0
 lint[output] {
 	is_addon_version_greater_than_or_equal("rook", "1.9.0")

--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -329,7 +329,7 @@ lint[output] {
 	}
 }
 
-# verifies velero 1.7.0 is not compatible with kubernetes versions >= 1.22+
+# verifies velero 1.6.2 is not compatible with kubernetes versions >= 1.22+
 lint[output] {
 	is_addon_version_greater_than_or_equal("kubernetes", "1.22.0")
 	is_addon_version_lower_than("velero", "1.6.3")

--- a/pkg/lint/tests/rego/valero_1.6.2_kube_gt_1.22.yaml
+++ b/pkg/lint/tests/rego/valero_1.6.2_kube_gt_1.22.yaml
@@ -1,0 +1,14 @@
+installer:
+  spec: 
+    kubernetes: 
+      version: 1.22.x
+    containerd: 
+      version: latest
+    weave:
+      version: latest
+    velero:
+      version: 1.6.2
+output:
+  - message: "Velero versions <= 1.6.2 are not compatible with Kubernetes versions 1.22+"
+    field: spec.velero.version
+    type: incompatibility


### PR DESCRIPTION
## Description

See that calico 1.6.2 cannot k8s versions >= 1.22+. From their docs: https://github.com/vmware-tanzu/velero#velero-compatibility-matrix

<img width="1048" alt="Screenshot 2023-02-09 at 16 26 27" src="https://user-images.githubusercontent.com/7708031/217875676-cdc61dfc-ff04-40b7-ae2a-f2702038abc2.png">

Partial fix for [sc-69028]