### PR TITLE
bug: linter should not return info severity by default

### DIFF
--- a/pkg/lint/rego/output.rego
+++ b/pkg/lint/rego/output.rego
@@ -552,6 +552,7 @@ lint[output] {
 
 # verifies docker is not compatible with rhel 9 compatible distributions
 lint[output] {
+	info_severity_enabled
 	installer.spec.docker.version != ""
 	output := {
 		"type": "incompatibility",
@@ -567,6 +568,7 @@ lint[output] {
 # verifies containerd versions less than 1.6.0 are not compatible with rhel 9 compatible
 # distributions
 lint[output] {
+	info_severity_enabled
 	is_addon_version_lower_than("containerd", "1.6.0")
 	output := {
 		"type": "incompatibility",

--- a/pkg/lint/tests/infosev/invalid_containerd_version.yaml
+++ b/pkg/lint/tests/infosev/invalid_containerd_version.yaml
@@ -1,0 +1,30 @@
+installer:
+  spec:
+    kubernetes:
+      version: 1.26.1
+    weave:
+      version: 2.8.1
+    containerd:
+      version: 0.0.1
+output:
+  - message: Unknown containerd add-on version 0.0.1
+    type: unknown-addon
+    severity: error
+    patch:
+      - op: replace
+        path: /spec/containerd/version
+        value: 1.6.18
+  - message: Kubernetes 1.26+ is not compatible with Containerd versions < 1.6.0
+    type: incompatibility
+    severity: error
+    patch:
+      - op: replace
+        path: /spec/containerd/version
+        value: 1.6.18
+  - message: Containerd versions < 1.6.0 are not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
+    type: incompatibility
+    severity: info
+    patch:
+      - op: replace
+        path: /spec/containerd/version
+        value: 1.6.18

--- a/pkg/lint/tests/infosev/invalid_docker_version.yaml
+++ b/pkg/lint/tests/infosev/invalid_docker_version.yaml
@@ -1,0 +1,39 @@
+installer:
+  spec:
+    kubernetes:
+      version: latest
+    weave:
+      version: latest
+    docker:
+      version: 1.0.0
+output:
+  - message: Unknown docker add-on version 1.0.0
+    type: unknown-addon
+    severity: error
+    patch:
+      - op: replace
+        path: /spec/docker/version
+        value: 20.10.17
+  - message: "Add-on kubernetes has a more recent version: 1.26.1"
+    type: upgrade-available
+    severity: info
+    patch:
+      - op: replace
+        path: /spec/kubernetes/version
+        value: 1.26.1
+  - message: "Add-on weave has a more recent version: 2.8.1"
+    type: upgrade-available
+    severity: info
+    patch:
+      - op: replace
+        path: /spec/weave/version
+        value: 2.8.1
+  - message: Docker is not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
+    type: incompatibility
+    severity: info
+    patch:
+      - op: remove
+        path: /spec/docker
+      - op: add
+        path: /spec/containerd/version
+        value: 1.6.18

--- a/pkg/lint/tests/rego/invalid_containerd_version.yaml
+++ b/pkg/lint/tests/rego/invalid_containerd_version.yaml
@@ -14,10 +14,3 @@ output:
       - op: replace
         path: /spec/containerd/version
         value: 1.6.18
-  - message: Containerd versions < 1.6.0 are not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: replace
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/invalid_docker_version.yaml
+++ b/pkg/lint/tests/rego/invalid_docker_version.yaml
@@ -14,12 +14,3 @@ output:
       - op: replace
         path: /spec/docker/version
         value: 20.10.17
-  - message: Docker is not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: remove
-        path: /spec/docker
-      - op: add
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/invalid_flannel_docker.yaml
+++ b/pkg/lint/tests/rego/invalid_flannel_docker.yaml
@@ -16,12 +16,3 @@ output:
       - op: add
         path: /spec/containerd/version
         value: 1.6.18
-  - message: Docker is not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: remove
-        path: /spec/docker
-      - op: add
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/kubernetes_gte_1.24_plus_docker_container_runtime.yaml
+++ b/pkg/lint/tests/rego/kubernetes_gte_1.24_plus_docker_container_runtime.yaml
@@ -16,12 +16,3 @@ output:
       - op: add
         path: /spec/containerd/version
         value: 1.6.18
-  - message: Docker is not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: remove
-        path: /spec/docker
-      - op: add
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/kubernetes_gte_1.26_plus_containerd_lt_1.6.yaml
+++ b/pkg/lint/tests/rego/kubernetes_gte_1.26_plus_containerd_lt_1.6.yaml
@@ -14,10 +14,3 @@ output:
       - op: replace
         path: /spec/containerd/version
         value: 1.6.18
-  - message: Containerd versions < 1.6.0 are not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: replace
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/kubernetes_with_multiple_container_runtimes.yaml
+++ b/pkg/lint/tests/rego/kubernetes_with_multiple_container_runtimes.yaml
@@ -15,12 +15,3 @@ output:
     patch:
       - op: remove
         path: /spec/docker
-  - message: Docker is not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: remove
-        path: /spec/docker
-      - op: add
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/multiple_invalid_versions.yaml
+++ b/pkg/lint/tests/rego/multiple_invalid_versions.yaml
@@ -30,10 +30,3 @@ output:
       - op: replace
         path: /spec/ekco/version
         value: 0.26.3
-  - message: Containerd versions < 1.6.0 are not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: replace
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/rego/no_kubernetes_distribution_selected.yaml
+++ b/pkg/lint/tests/rego/no_kubernetes_distribution_selected.yaml
@@ -22,12 +22,3 @@ output:
       - op: add
         path: /spec/containerd/version
         value: 1.6.18
-  - message: Docker is not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: remove
-        path: /spec/docker
-      - op: add
-        path: /spec/containerd/version
-        value: 1.6.18

--- a/pkg/lint/tests/unmarshal/installer_invalid_versions.yaml
+++ b/pkg/lint/tests/unmarshal/installer_invalid_versions.yaml
@@ -35,10 +35,3 @@ output:
       - op: replace
         path: /spec/ekco/version
         value: 0.26.3
-  - message: Containerd versions < 1.6.0 are not compatible with RHEL 9, Oracle Linux 9, or Rocky Linux 9
-    type: incompatibility
-    severity: info
-    patch:
-      - op: replace
-        path: /spec/containerd/version
-        value: 1.6.18


### PR DESCRIPTION
Info severity has been hidden behind a flag by design. The current linter is returning info severity errors when it should not. This commit hides them behind the flag, as done with all others.