### PR TITLE
feat: kubeadm ignore-preflight-errors properties

### DIFF
--- a/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: installers.cluster.kurl.sh
 spec:
   group: cluster.kurl.sh
@@ -305,6 +304,8 @@ spec:
                     type: boolean
                   evictionThresholdResources:
                     type: string
+                  initIgnorePreflightErrors:
+                    type: string
                   kubeReserved:
                     type: boolean
                   kubeadmToken:
@@ -324,6 +325,8 @@ spec:
                   serviceCidrRange:
                     type: string
                   systemReservedResources:
+                    type: string
+                  upgradeIgnorePreflightErrors:
                     type: string
                   useStandardNodePortRange:
                     type: boolean

--- a/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/pkg/apis/cluster/v1beta1/installer_types.go
@@ -95,28 +95,30 @@ type Kotsadm struct {
 }
 
 type Kubernetes struct {
-	BootstrapToken              string `json:"bootstrapToken,omitempty" yaml:"bootstrapToken,omitempty"`
-	BootstrapTokenTTL           string `json:"bootstrapTokenTTL,omitempty" yaml:"bootstrapTokenTTL,omitempty"`
-	CertKey                     string `json:"certKey,omitempty" yaml:"certKey,omitempty"`
-	ControlPlane                bool   `json:"controlPlane,omitempty" yaml:"controlPlane,omitempty"`
-	HACluster                   bool   `json:"HACluster,omitempty" yaml:"HACluster,omitempty"`
-	ContainerLogMaxSize         string `json:"containerLogMaxSize,omitempty" yaml:"containerLogMaxSize,omitempty"`
-	ContainerLogMaxFiles        int    `json:"containerLogMaxFiles,omitempty" yaml:"containerLogMaxFiles,omitempty"`
-	KubeadmToken                string `json:"kubeadmToken,omitempty" yaml:"kubeadmToken,omitempty"`
-	KubeadmTokenCAHash          string `json:"kubeadmTokenCAHash,omitempty" yaml:"kubeadmTokenCAHash,omitempty"`
-	LoadBalancerAddress         string `json:"loadBalancerAddress,omitempty" yaml:"loadBalancerAddress,omitempty"`
-	LoadBalancerUseFirstPrimary bool   `json:"loadBalancerUseFirstPrimary,omitempty" yaml:"loadBalancerUseFirstPrimary,omitempty"`
-	MasterAddress               string `json:"masterAddress,omitempty" yaml:"masterAddress,omitempty"`
-	S3Override                  string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
-	ServiceCIDR                 string `json:"serviceCIDR,omitempty" yaml:"serviceCIDR,omitempty"`
-	ServiceCidrRange            string `json:"serviceCidrRange,omitempty" yaml:"serviceCidrRange,omitempty"`
-	UseStandardNodePortRange    bool   `json:"useStandardNodePortRange,omitempty" yaml:"useStandardNodePortRange,omitempty"`
-	KubeReserved                bool   `json:"kubeReserved,omitempty" yaml:"kubeReserved,omitempty"`
-	EvictionThresholdResources  string `json:"evictionThresholdResources,omitempty" yaml:"evictionThresholdResources,omitempty"`
-	SystemReservedResources     string `json:"systemReservedResources,omitempty" yaml:"systemReservedResources,omitempty"`
-	Version                     string `json:"version" yaml:"version"`
-	CisCompliance               bool   `json:"cisCompliance,omitempty" yaml:"cisCompliance,omitempty"`
-	ClusterName                 string `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	BootstrapToken               string `json:"bootstrapToken,omitempty" yaml:"bootstrapToken,omitempty"`
+	BootstrapTokenTTL            string `json:"bootstrapTokenTTL,omitempty" yaml:"bootstrapTokenTTL,omitempty"`
+	CertKey                      string `json:"certKey,omitempty" yaml:"certKey,omitempty"`
+	ControlPlane                 bool   `json:"controlPlane,omitempty" yaml:"controlPlane,omitempty"`
+	HACluster                    bool   `json:"HACluster,omitempty" yaml:"HACluster,omitempty"`
+	ContainerLogMaxSize          string `json:"containerLogMaxSize,omitempty" yaml:"containerLogMaxSize,omitempty"`
+	ContainerLogMaxFiles         int    `json:"containerLogMaxFiles,omitempty" yaml:"containerLogMaxFiles,omitempty"`
+	KubeadmToken                 string `json:"kubeadmToken,omitempty" yaml:"kubeadmToken,omitempty"`
+	KubeadmTokenCAHash           string `json:"kubeadmTokenCAHash,omitempty" yaml:"kubeadmTokenCAHash,omitempty"`
+	LoadBalancerAddress          string `json:"loadBalancerAddress,omitempty" yaml:"loadBalancerAddress,omitempty"`
+	LoadBalancerUseFirstPrimary  bool   `json:"loadBalancerUseFirstPrimary,omitempty" yaml:"loadBalancerUseFirstPrimary,omitempty"`
+	MasterAddress                string `json:"masterAddress,omitempty" yaml:"masterAddress,omitempty"`
+	S3Override                   string `json:"s3Override,omitempty" yaml:"s3Override,omitempty"`
+	ServiceCIDR                  string `json:"serviceCIDR,omitempty" yaml:"serviceCIDR,omitempty"`
+	ServiceCidrRange             string `json:"serviceCidrRange,omitempty" yaml:"serviceCidrRange,omitempty"`
+	UseStandardNodePortRange     bool   `json:"useStandardNodePortRange,omitempty" yaml:"useStandardNodePortRange,omitempty"`
+	KubeReserved                 bool   `json:"kubeReserved,omitempty" yaml:"kubeReserved,omitempty"`
+	EvictionThresholdResources   string `json:"evictionThresholdResources,omitempty" yaml:"evictionThresholdResources,omitempty"`
+	SystemReservedResources      string `json:"systemReservedResources,omitempty" yaml:"systemReservedResources,omitempty"`
+	Version                      string `json:"version" yaml:"version"`
+	CisCompliance                bool   `json:"cisCompliance,omitempty" yaml:"cisCompliance,omitempty"`
+	ClusterName                  string `json:"clusterName,omitempty" yaml:"clusterName,omitempty"`
+	InitIgnorePreflightErrors    string `json:"initIgnorePreflightErrors,omitempty" yaml:"initIgnorePreflightErrors,omitempty"`
+	UpgradeIgnorePreflightErrors string `json:"upgradeIgnorePreflightErrors,omitempty" yaml:"upgradeIgnorePreflightErrors,omitempty"`
 }
 
 type Kurl struct {

--- a/schemas/installer-cluster-v1beta1.json
+++ b/schemas/installer-cluster-v1beta1.json
@@ -432,6 +432,9 @@
             "evictionThresholdResources": {
               "type": "string"
             },
+            "initIgnorePreflightErrors": {
+              "type": "string"
+            },
             "kubeReserved": {
               "type": "boolean"
             },
@@ -460,6 +463,9 @@
               "type": "string"
             },
             "systemReservedResources": {
+              "type": "string"
+            },
+            "upgradeIgnorePreflightErrors": {
               "type": "string"
             },
             "useStandardNodePortRange": {

--- a/schemas/installer-kurl-v1beta1.json
+++ b/schemas/installer-kurl-v1beta1.json
@@ -432,6 +432,9 @@
             "evictionThresholdResources": {
               "type": "string"
             },
+            "initIgnorePreflightErrors": {
+              "type": "string"
+            },
             "kubeReserved": {
               "type": "boolean"
             },
@@ -460,6 +463,9 @@
               "type": "string"
             },
             "systemReservedResources": {
+              "type": "string"
+            },
+            "upgradeIgnorePreflightErrors": {
               "type": "string"
             },
             "useStandardNodePortRange": {


### PR DESCRIPTION
In support of https://github.com/replicatedhq/kURL/pull/4449

Adds the ability to ignore preflight errors on kubernetes upgrades.