### PR TITLE
feat(rook): per node device configuration

### DIFF
--- a/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
+++ b/config/crds/v1beta1/cluster.kurl.sh_installers.yaml
@@ -2197,6 +2197,8 @@ spec:
                     type: boolean
                   minimumNodeCount:
                     type: integer
+                  nodes:
+                    type: string
                   s3Override:
                     type: string
                   storageClassName:

--- a/pkg/apis/cluster/v1beta1/installer_types.go
+++ b/pkg/apis/cluster/v1beta1/installer_types.go
@@ -187,6 +187,7 @@ type K3S struct {
 
 type Rook struct {
 	BlockDeviceFilter          string `json:"blockDeviceFilter,omitempty" yaml:"blockDeviceFilter,omitempty"`
+	Nodes                      string `json:"nodes,omitempty" yaml:"nodes,omitempty"`
 	BypassUpgradeWarning       bool   `json:"bypassUpgradeWarning,omitempty" yaml:"bypassUpgradeWarning,omitempty"`
 	CephReplicaCount           int    `json:"cephReplicaCount,omitempty" yaml:"cephReplicaCount,omitempty"`
 	IsBlockStorageEnabled      bool   `json:"isBlockStorageEnabled,omitempty" yaml:"isBlockStorageEnabled,omitempty"`

--- a/schemas/installer-cluster-v1beta1.json
+++ b/schemas/installer-cluster-v1beta1.json
@@ -3203,6 +3203,9 @@
             "minimumNodeCount": {
               "type": "integer"
             },
+            "nodes": {
+              "type": "string"
+            },
             "s3Override": {
               "type": "string"
             },

--- a/schemas/installer-kurl-v1beta1.json
+++ b/schemas/installer-kurl-v1beta1.json
@@ -3203,6 +3203,9 @@
             "minimumNodeCount": {
               "type": "integer"
             },
+            "nodes": {
+              "type": "string"
+            },
             "s3Override": {
               "type": "string"
             },


### PR DESCRIPTION
Adds the ability to add per-node rook device configuration

https://github.com/replicatedhq/kurl.sh/pull/967

```
apiVersion: cluster.kurl.sh/v1beta1
kind: Installer
metadata: 
  name: fb51888
spec: 
  kubernetes: 
    version: 1.27.1
  containerd: 
    version: 1.6.20
  flannel: 
    version: 0.21.4
  ekco: 
    version: 0.26.5
  rook:
    version: 1.11.5
    nodes: |
      - name: ethanm-rook-11
        devices:
          - name: sdb
      - name: ethanm-rook-12
        devices:
          - name: sdb
      - name: ethanm-rook-13
        devices:
          - name: sdb
      - name: ethanm-rook-14
        devices:
          - name: sdb
          - name: sdc
```